### PR TITLE
Use bnum of num bigint

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,81 @@
+name: Rust
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --all --verbose
+
+  unit-tests:
+    
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Unit Tests
+      run: cargo test --all --verbose 
+
+  clippy:
+    
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Clippy
+      run: rustup component add clippy && cargo clippy --all --all-targets --all-features -- -D warnings
+
+  rustfmt:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Rustfmt
+      run: rustup component add rustfmt && cargo fmt --all -- --check
+
+  cross-compile-mips:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: cross-compile-mips
+      run: cargo install cross && cross test --target mips-unknown-linux-gnu
+
+  cross-compile-mips64:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: cross-compile-mips64
+      run: cargo install cross && cross test --target mips64-unknown-linux-gnuabi64
+
+
+  cross-compile-arm64:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: cross-compile-arm64
+      run: cargo install cross && cross test --target aarch64-unknown-linux-gnu
+
+  
+
+  
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "num256"
-version = "0.3.5"
+version = "0.4.0"
 authors = ["Justin Kilpatrick justin@althea.net", "Jehan <jehan.tremback@gmail.com>"]
 include = [
     "**/*.rs",
@@ -12,13 +12,11 @@ license-file = "LICENSE"
 edition = '2021'
 
 [dependencies]
-num = "0.4"
 serde = "1.0"
-num-derive = "0.3"
+bnum = {version = "0.5.0", features = ["num-traits"]}
 num-traits = "0.2"
-serde_derive = "1.0"
-lazy_static = "1.4"
 
 [dev-dependencies]
-serde_derive = "1.0"
 serde_json = "1.0"
+serde_derive = "1.0"
+lazy_static = "1.4"

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,7 +39,7 @@ impl ParseError {
 
 impl Display for ParseError {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{} {}", "(num256)", self.description())
+        write!(f, "(num256) {}", self.description())
     }
 }
 
@@ -51,6 +51,8 @@ impl Debug for ParseError {
 
 impl From<bnum::errors::ParseIntError> for ParseError {
     fn from(value: bnum::errors::ParseIntError) -> Self {
-        ParseError { kind: value.kind().clone() }
+        ParseError {
+            kind: value.kind().clone(),
+        }
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,0 +1,56 @@
+use core::fmt::{self, Debug, Display, Formatter};
+use std::num::IntErrorKind;
+
+#[derive(PartialEq, Eq, Clone)]
+pub struct ParseError {
+    pub kind: IntErrorKind,
+}
+
+impl ParseError {
+    pub const fn kind(&self) -> &IntErrorKind {
+        &self.kind
+    }
+
+    const fn description(&self) -> &str {
+        match &self.kind {
+            IntErrorKind::Empty => "attempt to parse integer from empty string",
+            IntErrorKind::InvalidDigit => {
+                "attempt to parse integer from string containing invalid digit"
+            }
+            IntErrorKind::PosOverflow => {
+                "attempt to parse integer too large to be represented by the target type"
+            }
+            IntErrorKind::NegOverflow => {
+                "attempt to parse integer too small to be represented by the target type"
+            }
+            IntErrorKind::Zero => {
+                "attempt to parse the integer `0` which cannot be represented by the target type"
+            }
+            _ => panic!("unsupported `IntErrorKind` variant"), // necessary as `IntErrorKind` is non-exhaustive
+        }
+    }
+}
+
+impl ParseError {
+    pub fn new(kind: IntErrorKind) -> ParseError {
+        ParseError { kind }
+    }
+}
+
+impl Display for ParseError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "{} {}", "(num256)", self.description())
+    }
+}
+
+impl Debug for ParseError {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        Display::fmt(&self, f)
+    }
+}
+
+impl From<bnum::errors::ParseIntError> for ParseError {
+    fn from(value: bnum::errors::ParseIntError) -> Self {
+        ParseError { kind: value.kind().clone() }
+    }
+}

--- a/src/int256.rs
+++ b/src/int256.rs
@@ -22,7 +22,7 @@ impl Int256 {
     /// o Uint256
     pub fn to_uint256(&self) -> Option<Uint256> {
         if *self < Int256::zero() {
-            return None;
+            None
         } else {
             Some(Uint256(self.0.unsigned_abs()))
         }

--- a/src/int256.rs
+++ b/src/int256.rs
@@ -39,10 +39,9 @@ impl Num for Int256 {
     fn from_str_radix(str: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
         let res = Int256(BInt::<256>::from_str_radix(str, radix)?);
         if res > Int256::max_value() {
-            return Err(Self::FromStrRadixErr::new(IntErrorKind::PosOverflow))
-
+            return Err(Self::FromStrRadixErr::new(IntErrorKind::PosOverflow));
         } else if res < Int256::min_value() {
-            return Err(Self::FromStrRadixErr::new(IntErrorKind::NegOverflow))
+            return Err(Self::FromStrRadixErr::new(IntErrorKind::NegOverflow));
         }
         Ok(res)
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,3 @@
-#[macro_use]
-extern crate num_derive;
-#[macro_use]
-extern crate lazy_static;
-
-extern crate num;
 extern crate serde;
 
 pub mod int256;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,8 @@ extern crate serde;
 
 pub mod int256;
 pub mod uint256;
+pub mod error;
 
 pub use int256::Int256;
 pub use uint256::Uint256;
+pub use error::ParseError;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,9 +1,9 @@
 extern crate serde;
 
+pub mod error;
 pub mod int256;
 pub mod uint256;
-pub mod error;
 
+pub use error::ParseError;
 pub use int256::Int256;
 pub use uint256::Uint256;
-pub use error::ParseError;

--- a/src/uint256.rs
+++ b/src/uint256.rs
@@ -1,44 +1,126 @@
 pub use super::Int256;
-use num::bigint::ParseBigIntError;
-use num::bigint::ToBigInt;
-use num::traits::ops::checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
-use num::BigUint;
-use num::Num;
-use num::{pow, Bounded, Zero};
+use bnum::errors::ParseIntError;
+use bnum::BUint;
+use num_traits::{
+    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Num, One, ToPrimitive,
+    Zero,
+};
 use serde::ser::Serialize;
 use serde::{Deserialize, Deserializer, Serializer};
 use std::default::Default;
 use std::fmt;
-use std::ops::{Add, AddAssign, Deref, Div, DivAssign, Mul, MulAssign, Sub, SubAssign};
+use std::ops::{Add, AddAssign, Deref, Div, DivAssign, Mul, MulAssign, Sub, SubAssign, Shl, Shr, ShlAssign, ShrAssign, Rem, RemAssign};
 use std::str::FromStr;
 
-#[derive(
-    Clone, PartialEq, Eq, PartialOrd, Ord, Hash, FromPrimitive, ToPrimitive, Zero, Default,
-)]
-pub struct Uint256(pub BigUint);
+#[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
+pub struct Uint256(pub BUint<256>);
 
 impl Uint256 {
-    pub fn from_bytes_le(slice: &[u8]) -> Uint256 {
-        Uint256(BigUint::from_bytes_le(slice))
-    }
-    pub fn from_bytes_be(slice: &[u8]) -> Uint256 {
-        if slice.len() >= 32 {
-            // if a value larger than 32 bytes is provided, take
-            // the first 32 bytes
-            Uint256(BigUint::from_bytes_be(&slice[0..32]))
+    pub fn from_le_bytes(slice: &[u8]) -> Uint256 {
+        // if the length is less than 32, pass that length
+        // if it is greater truncate
+        let end = if slice.len() <= 32 {
+            slice.len()
         } else {
-            Uint256(BigUint::from_bytes_be(slice))
-        }
+            32
+        };
+        Uint256(BUint::from_le_slice(&slice[0..end]).unwrap())
     }
-    pub fn from_str_radix(s: &str, radix: u32) -> Result<Uint256, ParseBigIntError> {
-        BigUint::from_str_radix(s, radix).map(Uint256)
+    pub fn from_be_bytes(slice: &[u8]) -> Uint256 {
+        // if the length is less than 32, pass that length
+        // if it is greater truncate
+        let end = if slice.len() <= 32 {
+            slice.len()
+        } else {
+            32
+        };
+    Uint256(BUint::from_be_slice(&slice[0..end]).unwrap())
+    }
+    pub fn to_be_bytes(&self) -> [u8; 32] {
+        let mut res = self.to_le_bytes();
+        res.reverse();
+        res
+    }
+    pub fn to_le_bytes(&self) -> [u8; 32] {
+        let mut res: [u8; 32] = [0; 32];
+        // the only function available to access the internal int representation is a bit by bit query
+        // so in order to turn this into a 256bit array we must mask and shift this data into each byte
+        for i in 0usize..256 {
+            // the target byte and bit we are currently focused on
+            let byte_index = i / 8;
+            let bit_index = i % 8;
+            // the bit we want to copy to the target
+            let bit = self.0.bit(i as u32);
+            // if true we mask a one with the byte at the right index
+            if bit {
+                let scratch_bit = 1u8 << bit_index;
+                res[byte_index] |= scratch_bit
+            }
+        }
+        res
+    }
+    pub fn from_str_radix(s: &str, radix: u32) -> Result<Uint256, ParseIntError> {
+        BUint::<256>::from_str_radix(s, radix).map(Uint256)
     }
     /// Converts value to a signed 256 bit integer
     pub fn to_int256(&self) -> Option<Int256> {
-        self.0
-            .to_bigint()
-            .filter(|value| value.bits() <= 255)
-            .map(Int256)
+        if *self <= Int256::max_value().to_uint256().unwrap() {
+            Some(Int256::from_str_radix(&self.to_str_radix(10), 10).unwrap())
+        } else {
+            None
+        }
+    }
+
+    /// Square root
+    pub fn sqrt(&self) -> Uint256 {
+        self.0.ilog(self.0).into()
+    }
+}
+
+impl One for Uint256 {
+    fn one() -> Self {
+        Uint256(BUint::<256>::ONE)
+    }
+}
+
+impl Zero for Uint256 {
+    fn zero() -> Self {
+        Uint256(BUint::<256>::ZERO)
+    }
+
+    fn is_zero(&self) -> bool {
+        *self == Uint256::zero()
+    }
+}
+
+impl FromPrimitive for Uint256 {
+    fn from_i64(n: i64) -> Option<Self> {
+        let val: Result<BUint<256>, _> = n.try_into();
+        match val {
+            Ok(v) => Some(Uint256(v)),
+            Err(_) => None,
+        }
+    }
+
+    fn from_u64(n: u64) -> Option<Self> {
+        let val: BUint<256> = n.into();
+        Some(Uint256(val))
+    }
+}
+
+impl ToPrimitive for Uint256 {
+    fn to_i64(&self) -> Option<i64> {
+        match self.0.try_into() {
+            Ok(v) => Some(v),
+            Err(_) => None,
+        }
+    }
+
+    fn to_u64(&self) -> Option<u64> {
+        match self.0.try_into() {
+            Ok(v) => Some(v),
+            Err(_) => None,
+        }
     }
 }
 
@@ -48,20 +130,21 @@ impl Bounded for Uint256 {
         Uint256::zero()
     }
     fn max_value() -> Self {
-        lazy_static! {
-            static ref MAX_VALUE: BigUint = pow(BigUint::from(2u32), 256) - BigUint::from(1u32);
-        }
-        Uint256(MAX_VALUE.clone())
+        let max_value: Uint256 =
+            "115792089237316195423570985008687907853269984665640564039457584007913129639935"
+                .parse()
+                .unwrap();
+        max_value
     }
 }
 
 impl FromStr for Uint256 {
-    type Err = ParseBigIntError;
+    type Err = ParseIntError;
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         if let Some(val) = s.strip_prefix("0x") {
-            Ok(BigUint::from_str_radix(val, 16).map(Uint256)?)
+            Ok(BUint::<256>::from_str_radix(val, 16).map(Uint256)?)
         } else {
-            Ok(BigUint::from_str_radix(s, 10).map(Uint256)?)
+            Ok(BUint::<256>::from_str_radix(s, 10).map(Uint256)?)
         }
     }
 }
@@ -115,9 +198,9 @@ impl fmt::UpperHex for Uint256 {
 }
 
 impl Deref for Uint256 {
-    type Target = BigUint;
+    type Target = BUint<256>;
 
-    fn deref(&self) -> &BigUint {
+    fn deref(&self) -> &BUint<256> {
         &self.0
     }
 }
@@ -148,7 +231,7 @@ impl<'de> Deserialize<'de> for Uint256 {
         };
 
         // Create Uint256 given the sliced data, and radix
-        BigUint::from_str_radix(data, radix)
+        BUint::<256>::from_str_radix(data, radix)
             .map(Uint256)
             .map_err(serde::de::Error::custom)
     }
@@ -156,25 +239,31 @@ impl<'de> Deserialize<'de> for Uint256 {
 
 impl From<[u8; 32]> for Uint256 {
     fn from(n: [u8; 32]) -> Uint256 {
-        Uint256(BigUint::from_bytes_be(&n))
+        Uint256::from_be_bytes(&n)
     }
 }
 
 impl<'a> From<&'a [u8]> for Uint256 {
     fn from(n: &'a [u8]) -> Uint256 {
-        // if a value larger than 32 bytes is provided, take
-        // the first 32 bytes
-        Uint256(BigUint::from_bytes_be(&n[0..32]))
+        Uint256::from_be_bytes(n)
+    }
+}
+
+impl TryFrom<Int256> for Uint256 {
+    type Error = ();
+
+    fn try_from(value: Int256) -> Result<Self, Self::Error> {
+        match value.to_uint256() {
+            Some(v) => Ok(v),
+            None => Err(()),
+        }
     }
 }
 
 #[allow(clippy::from_over_into)]
 impl Into<[u8; 32]> for Uint256 {
     fn into(self) -> [u8; 32] {
-        let bytes = self.0.to_bytes_be();
-        let mut res: [u8; 32] = Default::default();
-        res[32 - bytes.len()..].copy_from_slice(&bytes);
-        res
+        self.to_be_bytes()
     }
 }
 
@@ -183,7 +272,7 @@ macro_rules! uint_impl_from_uint {
         impl From<$T> for Uint256 {
             #[inline]
             fn from(n: $T) -> Self {
-                Uint256(BigUint::from(n))
+                Uint256(BUint::<256>::from(n))
             }
         }
     };
@@ -206,10 +295,12 @@ macro_rules! forward_op {
             fn $method(self, $type_(b): $type_) -> $type_ {
                 let $type_(a) = self;
                 let res = a.$method(&b);
-                if res.bits() > 256 {
+                let res = Uint256(res);
+                // bounds check
+                if res > Uint256::max_value() || res < Uint256::min_value() {
                     panic!("attempt to {} with overflow", stringify!($method));
                 }
-                $type_(res)
+                res
             }
         }
     };
@@ -221,9 +312,19 @@ macro_rules! forward_checked_op {
         impl $trait_ for $type_ {
             fn $method(&self, $type_(b): &$type_) -> Option<$type_> {
                 let $type_(a) = self;
-                a.$method(&b)
-                    .filter(|value| value.bits() <= 256)
-                    .map($type_)
+                let value = a.$method(*b);
+                match value {
+                    Some(value) => {
+                        let value = Uint256(value);
+                        // bounds check
+                        if value > Uint256::max_value() || value < Uint256::min_value() {
+                            None
+                        } else {
+                            Some(value)
+                        }
+                    }
+                    None => None,
+                }
             }
         }
     };
@@ -236,7 +337,8 @@ macro_rules! forward_assign_op {
             fn $method(&mut self, $type_(b): $type_) {
                 let a = &mut self.0;
                 a.$method(b);
-                if a.bits() > 256 {
+                // bounds check
+                if *self > Uint256::max_value() || *self < Uint256::min_value() {
                     panic!("attempt to {} with overflow", stringify!($method));
                 }
             }
@@ -259,6 +361,15 @@ forward_assign_op! { impl MulAssign for Uint256 { fn mul_assign } }
 forward_op! { impl Div for Uint256 { fn div } }
 forward_checked_op! { impl CheckedDiv for Uint256 { fn checked_div } }
 forward_assign_op! { impl DivAssign for Uint256 { fn div_assign } }
+
+forward_op! { impl Shl for Uint256 { fn shl } }
+forward_assign_op! { impl ShlAssign for Uint256 { fn shl_assign } }
+
+forward_op! { impl Shr for Uint256 { fn shr } }
+forward_assign_op! { impl ShrAssign for Uint256 { fn shr_assign } }
+
+forward_op! { impl Rem for Uint256 { fn rem } }
+forward_assign_op! { impl RemAssign for Uint256 { fn rem_assign } }
 
 #[test]
 fn create_from_32_bytes() {

--- a/src/uint256.rs
+++ b/src/uint256.rs
@@ -10,7 +10,10 @@ use serde::{Deserialize, Deserializer, Serializer};
 use std::default::Default;
 use std::fmt;
 use std::num::IntErrorKind;
-use std::ops::{Add, AddAssign, Deref, Div, DivAssign, Mul, MulAssign, Sub, SubAssign, Shl, Shr, ShlAssign, ShrAssign, Rem, RemAssign};
+use std::ops::{
+    Add, AddAssign, Deref, Div, DivAssign, Mul, MulAssign, Rem, RemAssign, Shl, ShlAssign, Shr,
+    ShrAssign, Sub, SubAssign,
+};
 use std::str::FromStr;
 
 #[derive(Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Default)]
@@ -20,22 +23,14 @@ impl Uint256 {
     pub fn from_le_bytes(slice: &[u8]) -> Uint256 {
         // if the length is less than 32, pass that length
         // if it is greater truncate
-        let end = if slice.len() <= 32 {
-            slice.len()
-        } else {
-            32
-        };
+        let end = if slice.len() <= 32 { slice.len() } else { 32 };
         Uint256(BUint::from_le_slice(&slice[0..end]).unwrap())
     }
     pub fn from_be_bytes(slice: &[u8]) -> Uint256 {
         // if the length is less than 32, pass that length
         // if it is greater truncate
-        let end = if slice.len() <= 32 {
-            slice.len()
-        } else {
-            32
-        };
-    Uint256(BUint::from_be_slice(&slice[0..end]).unwrap())
+        let end = if slice.len() <= 32 { slice.len() } else { 32 };
+        Uint256(BUint::from_be_slice(&slice[0..end]).unwrap())
     }
     pub fn to_be_bytes(&self) -> [u8; 32] {
         let mut res = self.to_le_bytes();
@@ -81,10 +76,9 @@ impl Num for Uint256 {
     fn from_str_radix(str: &str, radix: u32) -> Result<Self, Self::FromStrRadixErr> {
         let res = Uint256(BUint::<256>::from_str_radix(str, radix)?);
         if res > Uint256::max_value() {
-            return Err(Self::FromStrRadixErr::new(IntErrorKind::PosOverflow))
-
+            return Err(Self::FromStrRadixErr::new(IntErrorKind::PosOverflow));
         } else if res < Uint256::min_value() {
-            return Err(Self::FromStrRadixErr::new(IntErrorKind::NegOverflow))
+            return Err(Self::FromStrRadixErr::new(IntErrorKind::NegOverflow));
         }
         Ok(res)
     }
@@ -474,7 +468,8 @@ fn check_display() {
 
 #[test]
 fn check_from_str_radix_overflow() {
-    let super_huge = "115792089237316195423570985008687907853369984665640564039457584007913129639935";
+    let super_huge =
+        "115792089237316195423570985008687907853369984665640564039457584007913129639935";
     let val = Uint256::from_str_radix(super_huge, 10);
     assert!(val.is_err())
 }

--- a/src/uint256.rs
+++ b/src/uint256.rs
@@ -175,7 +175,7 @@ impl fmt::LowerHex for Uint256 {
                 write!(f, "{}", &pad)?;
             }
         }
-        write!(f, "{}", hex_str)
+        write!(f, "{hex_str}")
     }
 }
 
@@ -193,7 +193,7 @@ impl fmt::UpperHex for Uint256 {
                 write!(f, "{}", &pad)?;
             }
         }
-        write!(f, "{}", hex_str)
+        write!(f, "{hex_str}")
     }
 }
 
@@ -393,19 +393,19 @@ fn to_hex() {
         .parse()
         .unwrap();
     assert_eq!(
-        format!("{:#x}", lhs),
+        format!("{lhs:#x}"),
         "0xbabababababababababababababababababababababababababababababababa"
     );
     assert_eq!(
-        format!("{:x}", lhs),
+        format!("{lhs:x}"),
         "babababababababababababababababababababababababababababababababa"
     );
     assert_eq!(
-        format!("{:X}", lhs),
+        format!("{lhs:X}"),
         "BABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA"
     );
     assert_eq!(
-        format!("{:#X}", lhs),
+        format!("{lhs:#X}"),
         "0xBABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABABA"
     );
 }
@@ -416,19 +416,19 @@ fn to_hex_with_padding() {
         .parse()
         .unwrap();
     assert_eq!(
-        format!("{:#066x}", lhs),
+        format!("{lhs:#066x}"),
         "0x0000000000bababababababababababababababababababababababababababa"
     );
     assert_eq!(
-        format!("{:064x}", lhs),
+        format!("{lhs:064x}"),
         "0000000000bababababababababababababababababababababababababababa"
     );
     assert_eq!(
-        format!("{:064X}", lhs),
+        format!("{lhs:064X}"),
         "0000000000BABABABABABABABABABABABABABABABABABABABABABABABABABABA"
     );
     assert_eq!(
-        format!("{:#066X}", lhs),
+        format!("{lhs:#066X}"),
         "0x0000000000BABABABABABABABABABABABABABABABABABABABABABABABABABABA"
     );
 }
@@ -450,7 +450,7 @@ fn into_array() {
 fn check_display() {
     let val = Uint256::max_value();
     assert_eq!(
-        format!("{}", val),
+        format!("{val}"),
         "115792089237316195423570985008687907853269984665640564039457584007913129639935"
     );
     assert_eq!(

--- a/tests/num256_test.rs
+++ b/tests/num256_test.rs
@@ -1,30 +1,21 @@
 extern crate num256;
 #[macro_use]
 extern crate lazy_static;
-extern crate num;
 extern crate serde_json;
 #[macro_use]
 extern crate serde_derive;
 extern crate serde;
 
-use num::pow::pow;
-use num::traits::cast::ToPrimitive;
-use num::traits::ops::checked::{CheckedAdd, CheckedDiv, CheckedMul, CheckedSub};
-use num::Signed;
-use num::{BigUint, Bounded, Zero};
 use num256::{Int256, Uint256};
+use num_traits::{Bounded, Zero, Signed, CheckedAdd, CheckedSub, ToPrimitive, CheckedMul};
 use std::ops::{Add, Div, Sub};
 
 lazy_static! {
     static ref BIGGEST_UINT: Uint256 = {
-        let res = pow(BigUint::from(2u8), 256) - BigUint::from(1u8);
-        assert!(res.bits() == 256);
-        Uint256(res)
+        Uint256::max_value()
     };
     static ref BIGGEST_INT_AS_UINT: Uint256 = {
-        let mut biggest_int_le = [255u8; 32];
-        biggest_int_le[31] = 127;
-        Uint256::from_bytes_le(&biggest_int_le)
+        Int256::max_value().to_uint256().unwrap()
     };
 }
 
@@ -218,11 +209,11 @@ fn test_uint_from_div_panic() {
 fn test_uint_from_checked_div() {
     assert!(BIGGEST_UINT
         .clone()
-        .checked_div(&Uint256::from(0u8))
+        .checked_div(*Uint256::from(0u8))
         .is_none());
     assert!(BIGGEST_UINT
         .clone()
-        .checked_div(&Uint256::from(5u8))
+        .checked_div(*Uint256::from(5u8))
         .is_some());
 }
 

--- a/tests/num256_test.rs
+++ b/tests/num256_test.rs
@@ -7,16 +7,12 @@ extern crate serde_derive;
 extern crate serde;
 
 use num256::{Int256, Uint256};
-use num_traits::{Bounded, Zero, Signed, CheckedAdd, CheckedSub, ToPrimitive, CheckedMul};
+use num_traits::{Bounded, CheckedAdd, CheckedMul, CheckedSub, Signed, ToPrimitive, Zero};
 use std::ops::{Add, Div, Sub};
 
 lazy_static! {
-    static ref BIGGEST_UINT: Uint256 = {
-        Uint256::max_value()
-    };
-    static ref BIGGEST_INT_AS_UINT: Uint256 = {
-        Int256::max_value().to_uint256().unwrap()
-    };
+    static ref BIGGEST_UINT: Uint256 = Uint256::max_value();
+    static ref BIGGEST_INT_AS_UINT: Uint256 = Int256::max_value().to_uint256().unwrap();
 }
 
 #[derive(Serialize, Deserialize, Debug)]
@@ -28,7 +24,7 @@ pub struct MyStruct {
 #[test]
 fn serialize() {
     let struc = MyStruct {
-        uint: BIGGEST_UINT.clone(),
+        uint: *BIGGEST_UINT,
         int: Int256::min_value(),
     };
 
@@ -72,7 +68,7 @@ fn test_from_uint() {
 #[test]
 #[should_panic]
 fn test_from_uint_to_int() {
-    let uint = BIGGEST_UINT.clone();
+    let uint = *BIGGEST_UINT;
     let _res = uint.to_int256().unwrap();
 }
 
@@ -96,30 +92,30 @@ fn test_from_int() {
 #[test]
 #[should_panic]
 fn test_uint_add_panic() {
-    let _val = BIGGEST_UINT.clone() + Uint256::from(1u32);
+    let _val = *BIGGEST_UINT + Uint256::from(1u32);
 }
 
 #[test]
 #[should_panic]
 fn test_uint_add_assign_panic() {
-    let mut val = BIGGEST_UINT.clone();
+    let mut val = *BIGGEST_UINT;
     val += Uint256::from(1u32);
 }
 
 #[test]
 fn test_uint_add_no_panic() {
-    let _val = BIGGEST_UINT.clone() + Uint256::from(0u32);
+    let _val = *BIGGEST_UINT + Uint256::from(0u32);
 }
 
 #[test]
 #[should_panic]
 fn test_uint_from_add_panic() {
-    let _val = BIGGEST_UINT.clone().add(Uint256::from(1u8));
+    let _val = (*BIGGEST_UINT).add(Uint256::from(1u8));
 }
 
 #[test]
 fn test_uint_from_add_no_panic() {
-    let _val = BIGGEST_UINT.clone().add(Uint256::zero());
+    let _val = (*BIGGEST_UINT).add(Uint256::zero());
 }
 
 #[test]
@@ -153,7 +149,7 @@ fn test_uint_from_sub_no_panic() {
 #[test]
 #[should_panic]
 fn test_uint_mul_panic() {
-    let _val: Uint256 = BIGGEST_UINT.clone() * Uint256::from(2u8);
+    let _val: Uint256 = *BIGGEST_UINT * Uint256::from(2u8);
 }
 
 #[test]
@@ -173,13 +169,13 @@ fn test_uint_mul_no_panic() {
 #[test]
 #[should_panic]
 fn test_uint_from_mul_panic() {
-    let _val = BIGGEST_UINT.clone() * Uint256::from(2u8);
+    let _val = *BIGGEST_UINT * Uint256::from(2u8);
 }
 
 #[test]
 #[should_panic]
 fn test_uint_from_mul_assign_panic() {
-    let mut val = BIGGEST_UINT.clone();
+    let mut val = *BIGGEST_UINT;
     val *= Uint256::from(2u8);
 }
 
@@ -191,7 +187,7 @@ fn test_uint_from_mul_no_panic() {
 #[test]
 #[should_panic]
 fn test_uint_div_panic() {
-    let _val = BIGGEST_UINT.clone() / Uint256::zero();
+    let _val = *BIGGEST_UINT / Uint256::zero();
 }
 
 #[test]
@@ -202,7 +198,7 @@ fn test_uint_div_no_panic() {
 #[test]
 #[should_panic]
 fn test_uint_from_div_panic() {
-    let _val = BIGGEST_UINT.clone().div(Uint256::from(0u8));
+    let _val = (*BIGGEST_UINT).div(Uint256::from(0u8));
 }
 
 #[test]
@@ -466,7 +462,7 @@ fn test_negate() {
 #[test]
 #[should_panic]
 fn test_uint_to_int() {
-    let value = BIGGEST_UINT.clone();
+    let value = *BIGGEST_UINT;
     value.to_int256().unwrap();
 }
 


### PR DESCRIPTION
This patch represents a major overhaul of this crate, moving it from a
wrapper around num_bigint to a crate called bnum which uses const
generics to achieve clone-able integers of dynamic size at compile time
but fixed size at runtime.

The goal here is both to reduce the number of dependencies involved in
this crate (35 -> 9), increase the number of native passthrough operators, and to
eliminate the constant need for clone while using this crate.

fixes #16 