### PR TITLE
Fix integer size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "num256"
-version = "0.4.1"
+version = "0.5.0"
 authors = ["Justin Kilpatrick justin@althea.net", "Jehan <jehan.tremback@gmail.com>"]
 include = [
     "**/*.rs",

--- a/tests/num256_test.rs
+++ b/tests/num256_test.rs
@@ -483,6 +483,9 @@ fn test_biggest_unsigned_to_int() {
 
 #[test]
 fn test_abs() {
-    let very_small: Int256 = Int256::min_value();
-    let _very_large: Uint256 = very_small.abs().to_uint256().unwrap();
+    // if we don't subtract a small number we will overflow since Uint256 max
+    // is one smaller than min
+    let very_small: Int256 = Int256::min_value() + 50.into();
+    let abs = very_small.abs();
+    let _very_large: Uint256 = abs.to_uint256().unwrap();
 }


### PR DESCRIPTION
This patch fixes an integer size problem, as it turns out the const generic factor for integer width in bnum is in units of 64bits, not single bits. Meaning this library was using 16,384 bit integers not 256 bit! Since the internal type is exposed publicly this is a breaking change and requires a version bump.