### PR TITLE
Replace To and FromPrimitive default implementations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "num256"
-version = "0.5.0"
+version = "0.5.1"
 authors = ["Justin Kilpatrick justin@althea.net", "Jehan <jehan.tremback@gmail.com>"]
 include = [
     "**/*.rs",


### PR DESCRIPTION
The default implementations of to_u128, to_i128, from_u128 and from_i128 were incorrect for values with absolute value at or above u64 max because the default will first convert the primitive to u64/i64, these bespoke implementations fix the issue.