### PR TITLE
Impl Pow + TryFrom<&str> for Uint256 and Int256

### DIFF
--- a/src/int256.rs
+++ b/src/int256.rs
@@ -218,6 +218,14 @@ impl FromStr for Int256 {
     }
 }
 
+impl TryFrom<&str> for Int256 {
+    type Error = crate::error::ParseError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
 impl TryFrom<Uint256> for Int256 {
     type Error = ();
 

--- a/src/int256.rs
+++ b/src/int256.rs
@@ -1,7 +1,7 @@
 use bnum::types::I256;
 use bnum::BInt;
 use num_traits::{
-    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Num, One, Signed,
+    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Num, One, Pow, Signed,
     ToPrimitive, Zero,
 };
 use serde::ser::Serialize;
@@ -290,6 +290,14 @@ impl Signed for Int256 {
     }
     fn is_negative(&self) -> bool {
         self.0.is_negative()
+    }
+}
+
+impl Pow<u32> for Int256 {
+    type Output = Self;
+
+    fn pow(self, p: u32) -> Self::Output {
+        Int256(self.0.pow(p))
     }
 }
 

--- a/src/uint256.rs
+++ b/src/uint256.rs
@@ -2,8 +2,8 @@ pub use super::Int256;
 use bnum::types::U256;
 use bnum::BUint;
 use num_traits::{
-    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Num, One, ToPrimitive,
-    Zero,
+    Bounded, CheckedAdd, CheckedDiv, CheckedMul, CheckedSub, FromPrimitive, Num, One, Pow,
+    ToPrimitive, Zero,
 };
 use serde::ser::Serialize;
 use serde::{Deserialize, Deserializer, Serializer};
@@ -306,6 +306,14 @@ impl TryFrom<Int256> for Uint256 {
 impl Into<[u8; 32]> for Uint256 {
     fn into(self) -> [u8; 32] {
         self.to_be_bytes()
+    }
+}
+
+impl Pow<u32> for Uint256 {
+    type Output = Self;
+
+    fn pow(self, p: u32) -> Self::Output {
+        Uint256(self.0.pow(p))
     }
 }
 

--- a/src/uint256.rs
+++ b/src/uint256.rs
@@ -183,6 +183,14 @@ impl FromStr for Uint256 {
     }
 }
 
+impl TryFrom<&str> for Uint256 {
+    type Error = crate::error::ParseError;
+
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        value.parse()
+    }
+}
+
 impl fmt::Display for Uint256 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(f, "{}", &self.0.to_str_radix(10))


### PR DESCRIPTION
Trying to use Uint256 with CLAP is quite annoying, since `#[clap(parse(try_from_str))]` is not available for the type